### PR TITLE
feat: add support severity for SyslogFormatter

### DIFF
--- a/Sources/Cosmic/Base/LogLevel.swift
+++ b/Sources/Cosmic/Base/LogLevel.swift
@@ -35,4 +35,16 @@ public enum LogLevel: UInt {
         default:        return ""
         }
     }
+
+    /// The Syslog severity value
+    /// See: https://tools.ietf.org/html/rfc5424#section-6.2.1
+    var syslogSeverity: Int {
+        switch self {
+        case .debug:    return 7
+        case .info:     return 6
+        case .warn:     return 4
+        case .error:    return 3
+        case .none:     return 0
+        }
+    }
 }

--- a/Sources/Cosmic/Formatters/SyslogFormatter.swift
+++ b/Sources/Cosmic/Formatters/SyslogFormatter.swift
@@ -17,22 +17,24 @@ class SyslogFormatter: LogFormatter {
     /// '1' is the only acceptable value.
     let SyslogVersion: String = "1"
     
-    /// The Syslog priority value
+    /// The Syslog facility value (mail system)
     /// See: https://tools.ietf.org/html/rfc5424#section-6.2.1
-    let SyslogPriority: String = "22"
+    let SyslogFacility = 16
     
     /// The syslog sendername value
     let SyslogSenderName: String = "Cosmic"
     
-    var SyslogHeader: String { return "<\(SyslogPriority)>\(SyslogVersion)" }
-    
     /// The Syslog sender value. This should be configured to
     /// a name describing the calling application or service
     var sender: String = Bundle.main.bundleIdentifier ?? "Unknown"
-    
+
+    func syslogHeader(_ logLevel: LogLevel) -> String {
+        return "<\(SyslogFacility + logLevel.syslogSeverity)>\(SyslogVersion)"
+    }
+
     func format(message: String, logLevel: LogLevel, metadata: LogMetadata) -> String {
         let timestamp = Date().iso8601
-        return "\(SyslogHeader) \(timestamp) \(SyslogSenderName) \(sender) - - - \(message)"
+        return "\(syslogHeader(logLevel)) \(timestamp) \(SyslogSenderName) \(sender) - - - \(message)"
     }
     
 }


### PR DESCRIPTION
Hi @jnewc 

I just start using PapertrailLogger for logging to cloud then aware all of the logs are displayed as `info` severity in papertrail.
This PR add support syslog severity for SyslogFormatter.
